### PR TITLE
Handle HTR data

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Level1AStack(
     "Level1AStack",
     rac_bucket_name="ops-payload-level0-v0.1",
     platform_bucket_name="ops-platform-level1a-v0.1",
-    output_bucket_name="ops-payload-level1a-v0.1",
+    output_bucket_name="ops-payload-level1a-v0.2",
 )
 
 app.synth()

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -20,9 +20,9 @@ Event = Dict[str, Any]
 Context = Any
 
 OFFSET_FACTOR = 2
-ORBIT_FREQUENCY = 0.1
-ATTITUDE_FREQUENCY = 1.
-HTR_FREQUENCY = 0.1
+ORBIT_FREQUENCY = 0.1  # Hz
+ATTITUDE_FREQUENCY = 1.  # Hz
+HTR_FREQUENCY = 0.1  # Hz
 
 PLATFORM_PREFIXES = {
     "HK_ecPowOps_1", "PreciseAttitudeEstimation", "PreciseOrbitEstimation",

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -22,11 +22,17 @@ Context = Any
 OFFSET_FACTOR = 2
 ORBIT_FREQUENCY = 0.1
 ATTITUDE_FREQUENCY = 1.
+HTR_FREQUENCY = 0.1
 
 PLATFORM_PREFIXES = {
     "HK_ecPowOps_1", "PreciseAttitudeEstimation", "PreciseOrbitEstimation",
     "scoCurrentScMode", "TM_acGnssOps", "TM_afAcsHiRateAttitudeData",
 }
+HTR_COLUMNS = [
+    "TMHeaderTime", "HTR1A", "HTR1B", "HTR1OD",
+    "HTR2A", "HTR2B", "HTR2OD", "HTR7A", "HTR7B", "HTR7OD", "HTR8A",
+    "HTR8B", "HTR8OD",
+]
 
 
 class DoesNotCover(Exception):
@@ -75,6 +81,25 @@ def get_ccd_records(
         path_or_bucket,
         filesystem=filesystem,
     ).to_pandas().set_index("EXPDate").sort_index()
+
+
+def get_htr_records(
+    path_or_bucket: str,
+    min_time: Timestamp,
+    max_time: Timestamp,
+    filesystem: pa.fs.FileSystem = None,
+) -> DataFrame:
+    dataset = ds.dataset(
+        path_or_bucket,
+        filesystem=filesystem,
+    ).to_table(
+        filter=(
+            (ds.field('TMHeaderTime') >= min_time)
+            & (ds.field('TMHeaderTime') <= max_time)
+        ),
+        columns=HTR_COLUMNS,
+    ).to_pandas().set_index("TMHeaderTime").sort_index()
+    return dataset
 
 
 def get_orbit_records(
@@ -170,6 +195,7 @@ def interpolate(dataframe: DataFrame, target: DatetimeIndex) -> DataFrame:
 def lambda_handler(event: Event, context: Context):
     output_bucket = get_or_raise("OUTPUT_BUCKET")
     platform_bucket = get_or_raise("PLATFORM_BUCKET")
+    htr_bucket = get_or_raise("HTR_BUCKET")
     region = os.environ.get('AWS_REGION', "eu-north-1")
     s3 = pa.fs.S3FileSystem(region=region)
 
@@ -212,19 +238,27 @@ def lambda_handler(event: Event, context: Context):
         max_time + get_offset(ORBIT_FREQUENCY),
         filesystem=s3,
     )
+    htr_df = get_htr_records(
+        f"{htr_bucket}/HTR",
+        min_time - get_offset(HTR_FREQUENCY),
+        max_time + get_offset(HTR_FREQUENCY),
+        filesystem=s3,
+    )
 
     if not covers(attitude_df.index, min_time, max_time):
         raise DoesNotCover("Attitude data is missing timestamps")
     if not covers(orbit_df.index, min_time, max_time):
         raise DoesNotCover("Orbit data is missing timestamps")
+    if not covers(htr_df.index, min_time, max_time):
+        raise DoesNotCover("HTR data is missing timestamps")
 
     attitude_subset = interpolate(attitude_df, rac_df.index)
     orbit_subset = interpolate(orbit_df, rac_df.index)
+    htr_subset = interpolate(htr_df, rac_df.index)
     out_table = pa.Table.from_pandas(concat(
-        [rac_df, attitude_subset, orbit_subset],
+        [rac_df, attitude_subset, orbit_subset, htr_subset],
         axis=1,
     ))
-
     pq.write_table(
         out_table,
         f"{output_bucket}/{object.strip('/CCD')}",

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -29,9 +29,8 @@ PLATFORM_PREFIXES = {
     "scoCurrentScMode", "TM_acGnssOps", "TM_afAcsHiRateAttitudeData",
 }
 HTR_COLUMNS = [
-    "TMHeaderTime", "HTR1A", "HTR1B", "HTR1OD",
-    "HTR2A", "HTR2B", "HTR2OD", "HTR7A", "HTR7B", "HTR7OD", "HTR8A",
-    "HTR8B", "HTR8OD",
+    "TMHeaderTime", "HTR1A", "HTR1B", "HTR1OD", "HTR2A", "HTR2B", "HTR2OD",
+    "HTR7A", "HTR7B", "HTR7OD", "HTR8A", "HTR8B", "HTR8OD",
 ]
 
 

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -56,6 +56,7 @@ class Level1AStack(Stack):
             environment={
                 "PLATFORM_BUCKET": platform_bucket_name,
                 "OUTPUT_BUCKET": output_bucket_name,
+                "HTR_BUCKET": rac_bucket_name,
             },
         )
 

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -51,7 +51,7 @@ class Level1AStack(Stack):
             timeout=lambda_timeout,
             architecture=Architecture.X86_64,
             runtime=Runtime.PYTHON_3_9,
-            memory_size=512,
+            memory_size=1024,
             ephemeral_storage_size=Size.mebibytes(512),
             environment={
                 "PLATFORM_BUCKET": platform_bucket_name,

--- a/tests/level1a/handlers/conftest.py
+++ b/tests/level1a/handlers/conftest.py
@@ -21,3 +21,8 @@ def platform_dir(data_dir):
 @pytest.fixture
 def ccd_path(rac_dir):
     return rac_dir / "CCD" / "2022" / "11" / "22" / "MATS_OPS_Level0_VC1_APID100_20221122-080636_20221122-094142.parquet"  # noqa: E501
+
+
+@pytest.fixture
+def htr_path(rac_dir):
+    return rac_dir / "HTR"

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -6,9 +6,11 @@ import numpy as np
 import pandas as pd  # type: ignore
 import pytest  # type: ignore
 from level1a.handlers.level1a import (
+    HTR_COLUMNS,
     covers,
     get_attitude_records,
     get_ccd_records,
+    get_htr_records,
     get_or_raise,
     get_orbit_records,
     get_search_bounds,
@@ -109,6 +111,29 @@ def test_get_ccd_records(ccd_path):
         out.index,
         expect_inds,
     )
+
+
+@pytest.mark.parametrize("min_time,max_time,rows", (
+    (
+        pd.Timestamp("2022-11-22T08:00:00+00:00"),
+        pd.Timestamp("2022-11-22T10:00:00+00:00"),
+        582
+    ),
+    (
+        pd.Timestamp("2022-11-22T08:00:00+00:00"),
+        pd.Timestamp("2022-11-22T09:00:00+00:00"),
+        338
+    ),
+    (
+        pd.Timestamp("2022-11-22T09:00:00+00:00"),
+        pd.Timestamp("2022-11-22T10:00:00+00:00"),
+        244
+    ),
+))
+def test_get_htr_records(htr_path, min_time, max_time, rows):
+    out = get_htr_records(htr_path, min_time, max_time)
+    assert set([*out.columns, out.index.name]) == set(HTR_COLUMNS)
+    assert len(out) == rows
 
 
 @pytest.mark.parametrize("min_time,max_time,rows", (

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -1,9 +1,12 @@
 import json
 import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd  # type: ignore
+import pyarrow.parquet as pq  # type: ignore
 import pytest  # type: ignore
 from level1a.handlers.level1a import (
     HTR_COLUMNS,
@@ -16,6 +19,7 @@ from level1a.handlers.level1a import (
     get_search_bounds,
     interp_array,
     interpolate,
+    lambda_handler,
     parse_event_message,
 )
 
@@ -245,3 +249,51 @@ def test_interpolate():
             index=datetimes,
         )
     )
+
+
+@patch("level1a.handlers.level1a.pa.fs.S3FileSystem", return_value=None)
+@patch.dict(os.environ, {
+    "OUTPUT_BUCKET": TemporaryDirectory().name,
+    "PLATFORM_BUCKET": str(Path(__file__).parent / "files" / "platform"),
+    "HTR_BUCKET": str(Path(__file__).parent / "files" / "rac"),
+})
+def test_lambda_handler(patched_s3):
+    out_dir = os.environ["OUTPUT_BUCKET"]
+    (Path(out_dir) / "2022" / "11" / "22").mkdir(parents=True)
+
+    out_file = "2022/11/22/MATS_OPS_Level0_VC1_APID100_20221122-080636_20221122-094142.parquet"  # noqa: E501
+
+    event = {
+        "Records": [{
+            "body": json.dumps({
+                "Records": [{
+                    "s3": {
+                        "bucket": {
+                            "name": str(Path(__file__).parent / "files" / "rac")
+                        },
+                        "object": {"key": f"CCD/{out_file}"}
+                    }
+                }]
+            }),
+        }],
+    }
+
+    lambda_handler(event, "")
+
+    df = pq.read_table(f"{out_dir}/{out_file}").to_pandas()
+    assert df.index.name == "EXPDate"
+    assert set(df.columns) == {
+        "OriginFile", "ProcessingTime", "RamsesTime", "QualityIndicator",
+        "LossFlag", "VCFrameCounter", "SPSequenceCount", "TMHeaderTime",
+        "TMHeaderNanoseconds", "SID", "RID", "CCDSEL", "EXPNanoseconds",
+        "WDWMode", "WDWInputDataWindow", "WDWOV", "JPEGQ", "FRAME", "NROW",
+        "NRBIN", "NRSKIP", "NCOL", "NCBINFPGAColumns", "NCBINCCDColumns",
+        "NCSKIP", "NFLUSH", "TEXPMS", "GAINMode", "GAINTiming",
+        "GAINTruncation", "TEMP", "FBINOV", "LBLNK", "TBLNK", "ZERO", "TIMING1",
+        "TIMING2", "VERSION", "TIMING3", "NBC", "BadColumns", "ImageName",
+        "ImageData", "Warnings", "Errors", "afsAttitudeState",
+        "afsTangentPoint", "acsGnssStateJ2000", "HTR1A", "HTR1B", "HTR1OD",
+        "HTR2A", "HTR2B", "HTR2OD", "HTR7A", "HTR7B", "HTR7OD", "HTR8A",
+        "HTR8B", "HTR8OD",
+    }
+    assert len(df) == 5


### PR DESCRIPTION
Resolves #5 

- Reads, interpolates all `HTR*` columns in the HTR data and writes it together with the other data
- Bumped version number on output bucket
- Added a test for the lambda handler