### PR TITLE
Drop duplicate rows when getting HTR records

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -97,7 +97,9 @@ def get_htr_records(
             & (ds.field('TMHeaderTime') <= max_time)
         ),
         columns=HTR_COLUMNS,
-    ).to_pandas().set_index("TMHeaderTime").sort_index()
+    ).to_pandas().drop_duplicates("TMHeaderTime").set_index(
+        "TMHeaderTime"
+    ).sort_index()
     return dataset
 
 


### PR DESCRIPTION
Apparently there's duplicates in the HTR dataset. Not sure if this is expected? Anyhow it causes the interpolation to fail so needs to be handled.