### PR TITLE
Return null when no interpolation possible for HTR

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -180,20 +180,17 @@ def interp_to(
     if (before < 0 or after < 0) or (before > after):
         return column.iloc[0] * np.nan
 
-    timestamps = column.index[[before, after]].astype(int).values
+    timestamps = column.index[[before, after]]
 
     if (
         max_diff is not None
-        and (
-            Timedelta(seconds=np.abs(timestamps[1] - timestamps[0]) * 1e-9)
-            > max_diff
-        )
+        and np.diff(timestamps)[0] > max_diff
     ):
         return column.iloc[0] * np.nan
 
     return interp_array(
         target_date.value,
-        timestamps,
+        timestamps.astype(int).values,
         column.iloc[[before, after]].values,
     )
 

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -229,6 +229,32 @@ def test_interp_array(eval_point, indices, values, expect):
 
 def test_interpolate():
     datetimes = pd.DatetimeIndex([
+        '2022-10-01T06:00:00',
+        '2022-11-01T06:00:00',
+        '2022-11-02T00:00:00',
+        '2022-11-02T18:00:00',
+        '2022-12-02T18:00:00',
+    ])
+    dataframe = pd.DataFrame(
+        [1., 2., 3., 4.],
+        index=pd.DatetimeIndex([
+            '2022-11-01T00:00:00',
+            '2022-11-01T12:00:00',
+            '2022-11-02T00:00:00',
+            '2022-11-03T00:00:00',
+        ])
+    )
+    pd.testing.assert_frame_equal(
+        interpolate(dataframe, datetimes),
+        pd.DataFrame(
+            [np.nan, 1.5, 3., 3.75, np.nan],
+            index=datetimes,
+        ),
+    )
+
+
+def test_interpolate_with_max_diff_returns_nan():
+    datetimes = pd.DatetimeIndex([
         '2022-11-01T06:00:00',
         '2022-11-02T00:00:00',
         '2022-11-02T18:00:00',
@@ -243,11 +269,11 @@ def test_interpolate():
         ])
     )
     pd.testing.assert_frame_equal(
-        interpolate(dataframe, datetimes),
+        interpolate(dataframe, datetimes, pd.Timedelta(hours=12)),
         pd.DataFrame(
-            [1.5, 3., 3.75],
+            [1.5, 3., np.nan],
             index=datetimes,
-        )
+        ),
     )
 
 


### PR DESCRIPTION
This PR stops failing entire file when HTR data does not cover the CCD data. Instead, rows where the interpolation cannot be performed, either because data is missing or the interval between data points is too large, the data for that point is set to `nan`. This is performed for all interpolated data, not just HTR, but should be uncommon for platform data, since they still raise when not covering.

**Note:** I interpreted setting to  `null` as setting to `nan`, but an alternative is possibly to set to `None` instead.

Resolves #18 