### PR TITLE
Bump in- and output versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,9 +11,9 @@ repo = git.Repo(".")
 Level1AStack(
     app,
     "Level1AStack",
-    rac_bucket_name="ops-payload-level0-v0.1",
+    rac_bucket_name="ops-payload-level0-v0.2",
     platform_bucket_name="ops-platform-level1a-v0.3",
-    output_bucket_name="ops-payload-level1a-v0.3",
+    output_bucket_name="ops-payload-level1a-v0.4",
     code_version=f"{repo.tags[-1]} ({repo.head.commit})",
 )
 


### PR DESCRIPTION
Bumps versions in anticipation of new partitioning. Note that buckets will need to be created.
We should also empty the DLQ.