### PR TITLE
Add photometer stack

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,11 +18,24 @@ except IndexError:
 
 Level1AStack(
     app,
-    "Level1AStack",
+    "Level1AStackCCD",
     rac_bucket_name="ops-payload-level0-v0.2",
     platform_bucket_name="ops-platform-level1a-v0.3",
     output_bucket_name="ops-payload-level1a-v0.5",
     code_version=f"{tag} ({repo.head.commit})",
+    data_prefix="CCD",
+    read_htr=True,
+)
+
+Level1AStack(
+    app,
+    "Level1AStackPM",
+    rac_bucket_name="ops-payload-level0-v0.2",
+    platform_bucket_name="ops-platform-level1a-v0.3",
+    output_bucket_name="ops-payload-level1a-PM-v0.1",
+    code_version=f"{tag} ({repo.head.commit})",
+    data_prefix="PM",
+    read_htr=False,
 )
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ Level1AStack(
     "Level1AStackPM",
     rac_bucket_name="ops-payload-level0-v0.2",
     platform_bucket_name="ops-platform-level1a-v0.3",
-    output_bucket_name="ops-payload-level1a-PM-v0.1",
+    output_bucket_name="ops-payload-level1a-pm-v0.1",
     code_version=f"{tag} ({repo.head.commit})",
     data_prefix="PM",
     read_htr=False,

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -454,10 +454,16 @@ def lambda_handler(event: Event, context: Context):
             raise Level1AException(msg)
 
     try:
-        out_table = pa.Table.from_pandas(concat(
-            [rac_df, reconstructed_df, htr_subset],
-            axis=1,
-        ))
+        if htr_bucket is not None:
+            out_table = pa.Table.from_pandas(concat(
+                [rac_df, reconstructed_df, htr_subset],
+                axis=1,
+            ))
+        else:
+            out_table = pa.Table.from_pandas(concat(
+                [rac_df, reconstructed_df],
+                axis=1,
+            ))
         out_table = out_table.replace_schema_metadata({
             **out_table.schema.metadata,
             **metadata,

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -367,14 +367,15 @@ def lambda_handler(event: Event, context: Context):
     try:
         output_bucket = get_or_raise("OUTPUT_BUCKET")
         platform_bucket = get_or_raise("PLATFORM_BUCKET")
-        htr_bucket = get_or_raise("HTR_BUCKET")
         code_version = get_or_raise("L1A_VERSION")
+        data_prefix = get_or_raise("DATA_PREFIX")
         region = os.environ.get('AWS_REGION', "eu-north-1")
+        htr_bucket = os.environ.get("HTR_BUCKET", None)
         s3 = pa.fs.S3FileSystem(region=region)
 
         try:
             bucket, object_path = parse_event_message(event)
-            output_path = object_path.strip("/CCD")
+            output_path = object_path.strip(f"/{data_prefix}")
         except InvalidMessage:
             return {
                 'statusCode': HTTPStatus.NO_CONTENT,
@@ -432,22 +433,23 @@ def lambda_handler(event: Event, context: Context):
         msg = f"Failed to get reconstructed data for {output_path} with start time {min_time} and end time {max_time}: {err} ({type(err)}; {tb})"  # noqa: E501
         raise Level1AException(msg)
 
-    try:
-        htr_df = get_htr_records(
-            f"{htr_bucket}/HTR",
-            min_time - get_offset(HTR_FREQUENCY),
-            max_time + get_offset(HTR_FREQUENCY),
-            filesystem=s3,
-        )
-        htr_subset = interpolate(
-            htr_df,
-            rac_df.index,
-            max_diff=get_offset(HTR_FREQUENCY),
-        )
-    except Exception as err:
-        tb = '|'.join(format_tb(err.__traceback__)).replace('\n', ';')
-        msg = f"Failed to get HTR data for {output_path} with start time {min_time} and end time {max_time}: {err} ({type(err)}; {tb})"  # noqa: E501
-        raise Level1AException(msg)
+    if htr_bucket is not None:
+        try:
+            htr_df = get_htr_records(
+                f"{htr_bucket}/HTR",
+                min_time - get_offset(HTR_FREQUENCY),
+                max_time + get_offset(HTR_FREQUENCY),
+                filesystem=s3,
+            )
+            htr_subset = interpolate(
+                htr_df,
+                rac_df.index,
+                max_diff=get_offset(HTR_FREQUENCY),
+            )
+        except Exception as err:
+            tb = '|'.join(format_tb(err.__traceback__)).replace('\n', ';')
+            msg = f"Failed to get HTR data for {output_path} with start time {min_time} and end time {max_time}: {err} ({type(err)}; {tb})"  # noqa: E501
+            raise Level1AException(msg)
 
     try:
         out_table = pa.Table.from_pandas(concat(

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -275,6 +275,7 @@ def test_interpolate_with_max_diff_returns_nan():
     "PLATFORM_BUCKET": str(Path(__file__).parent / "files" / "platform"),
     "HTR_BUCKET": str(Path(__file__).parent / "files" / "rac"),
     "L1A_VERSION": "latest.and.greatest",
+    "DATA_PREFIX": "CCD",
 })
 def test_lambda_handler(patched_s3):
     out_dir = os.environ["OUTPUT_BUCKET"]

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -319,3 +319,52 @@ def test_lambda_handler(patched_s3):
         "TPsza", "TPssa", "nadir_sza", "TPlocaltime",
     }
     assert len(df) == 4
+
+
+@patch("level1a.handlers.level1a.pa.fs.S3FileSystem", return_value=None)
+@patch.dict(os.environ, {
+    "OUTPUT_BUCKET": TemporaryDirectory().name,
+    "PLATFORM_BUCKET": str(Path(__file__).parent / "files" / "platform"),
+    "L1A_VERSION": "latest.and.greatest",
+    "DATA_PREFIX": "CCD",
+})
+def test_lambda_handler_no_htr(patched_s3):
+    out_dir = os.environ["OUTPUT_BUCKET"]
+    (Path(out_dir) / "2022" / "12" / "21" / "23").mkdir(parents=True)
+
+    out_file = "2022/12/21/23/MATS_OPS_Level0_VC1_APID100_20221221-132606_20221222-133247.parquet"  # noqa: E501
+
+    event = {
+        "Records": [{
+            "body": json.dumps({
+                "Records": [{
+                    "s3": {
+                        "bucket": {
+                            "name": str(Path(__file__).parent / "files" / "rac")
+                        },
+                        "object": {"key": f"CCD/{out_file}"}
+                    }
+                }]
+            }),
+        }],
+    }
+
+    lambda_handler(event, "")
+
+    df = pq.read_table(f"{out_dir}/{out_file}").to_pandas()
+    assert df.index.name == "EXPDate"
+    assert set(df.columns) == {
+        "OriginFile", "ProcessingTime", "RamsesTime", "QualityIndicator",
+        "LossFlag", "VCFrameCounter", "SPSequenceCount", "TMHeaderTime",
+        "TMHeaderNanoseconds", "SID", "RID", "CCDSEL", "EXPNanoseconds",
+        "WDWMode", "WDWInputDataWindow", "WDWOV", "JPEGQ", "FRAME", "NROW",
+        "NRBIN", "NRSKIP", "NCOL", "NCBINFPGAColumns", "NCBINCCDColumns",
+        "NCSKIP", "NFLUSH", "TEXPMS", "GAINMode", "GAINTiming",
+        "GAINTruncation", "TEMP", "FBINOV", "LBLNK", "TBLNK", "ZERO", "TIMING1",
+        "TIMING2", "VERSION", "TIMING3", "NBC", "BadColumns", "ImageName",
+        "ImageData", "Warnings", "Errors", "afsAttitudeState",
+        "afsGnssStateJ2000", "afsTPLongLatGeod", "afsTangentH_wgs84",
+        "afsTangentPointECI", "satlat", "satlon", "satheight", "TPlat", "TPlon",
+        "TPheight", "TPsza", "TPssa", "nadir_sza", "TPlocaltime",
+    }
+    assert len(df) == 4


### PR DESCRIPTION
This adds a stack for Photometer (PM) data alongside CCD data. Note that the stack changes name for CCD as well, so `cdk destroy` will need to be run manually before deploying to avoid issues with duplication.

Resolves #34 


