### PR TITLE
Longer message visibility and higher number of attempts

### DIFF
--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -25,7 +25,7 @@ class Level1AStack(Stack):
         lambda_timeout: Duration = Duration.minutes(15),
         queue_retention_period: Duration = Duration.days(14),
         message_timeout: Duration = Duration.hours(12),
-        message_retries: int = 4,
+        message_attempts: int = 4,
         code_version: str = "",
         **kwargs
     ) -> None:
@@ -76,7 +76,7 @@ class Level1AStack(Stack):
             visibility_timeout=message_timeout,
             removal_policy=RemovalPolicy.RETAIN,
             dead_letter_queue=DeadLetterQueue(
-                max_receive_count=message_retries,
+                max_receive_count=message_attempts,
                 queue=Queue(
                     self,
                     f"Failed{data_prefix}ProcessQueue",

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -22,8 +22,10 @@ class Level1AStack(Stack):
         data_prefix: str,
         time_column: str,
         read_htr: bool,
-        lambda_timeout: Duration = Duration.seconds(900),
+        lambda_timeout: Duration = Duration.minutes(15),
         queue_retention_period: Duration = Duration.days(14),
+        message_timeout: Duration = Duration.hours(12),
+        message_retries: int = 4,
         code_version: str = "",
         **kwargs
     ) -> None:
@@ -71,10 +73,10 @@ class Level1AStack(Stack):
         event_queue = Queue(
             self,
             f"Process{data_prefix}Queue",
-            visibility_timeout=lambda_timeout,
+            visibility_timeout=message_timeout,
             removal_policy=RemovalPolicy.RETAIN,
             dead_letter_queue=DeadLetterQueue(
-                max_receive_count=1,
+                max_receive_count=message_retries,
                 queue=Queue(
                     self,
                     f"Failed{data_prefix}ProcessQueue",


### PR DESCRIPTION
This sets message visibility timeout to 12 h and the number of attempts before going into DLQ to 4. Effectively this means that a message has 48 hours to find matching platform data before we give up and defer it to manual redrive from the DLQ. The hope is that for most messages will pass in the first 3 attempts (36 h), but we allow a fourth as a buffer.

Resolves #42 