### PR TITLE
Add support for parallel development pipeline

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,43 @@
+name: Level1A CD (Dev)
+
+on:
+  workflow_dispatch:
+
+env:
+  # NOTE: Any non-empty string is regarded as `True`, hence "YES"
+  MATS_DEVELOPMENT: "YES"
+
+jobs:
+  aws_cdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node 18
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: Install aws-cdk
+        run: |
+          npm install -g aws-cdk
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install python dependencies
+        run: |
+          python3.9 -m pip install -r requirements.txt
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Deploy stacks
+        run: cdk deploy --all --require-approval never

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 
 from typing import Optional
 
+import os
+
 import git
 from git import TagReference
 from aws_cdk import App
@@ -16,17 +18,26 @@ try:
 except IndexError:
     tag = None
 
+development = bool(os.environ.get("MATS_DEVELOPMENT", False))
+if development:
+    output_bucket_ccd = "dev-payload-level1a"
+    output_bucket_pm = "dev-payload-level1a-pm"
+else:
+    output_bucket_ccd = "ops-payload-level1a-v0.6"
+    output_bucket_pm = "ops-payload-level1a-pm-v0.3"
+
 Level1AStack(
     app,
     "Level1AStackCCD",
     rac_bucket_name="ops-payload-level0-v0.3",
     platform_bucket_name="ops-platform-level1a-v0.3",
     mats_schedule_bucket_name="ops-schedule-v0.1",
-    output_bucket_name="ops-payload-level1a-v0.6",
+    output_bucket_name=output_bucket_ccd,
     code_version=f"{tag} ({repo.head.commit})",
     data_prefix="CCD",
     time_column="EXPDate",
     read_htr=True,
+    development=development,
 )
 
 Level1AStack(
@@ -35,11 +46,12 @@ Level1AStack(
     rac_bucket_name="ops-payload-level0-v0.3",
     platform_bucket_name="ops-platform-level1a-v0.3",
     mats_schedule_bucket_name="ops-schedule-v0.1",
-    output_bucket_name="ops-payload-level1a-pm-v0.3",
+    output_bucket_name=output_bucket_pm,
     code_version=f"{tag} ({repo.head.commit})",
     data_prefix="PM",
     time_column="PMTime",
     read_htr=False,
+    development=development,
 )
 
 app.synth()

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -28,31 +28,32 @@ class Level1AStack(Stack):
         message_timeout: Duration = Duration.hours(12),
         message_attempts: int = 4,
         code_version: str = "",
+        development: bool = False,
         **kwargs
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
         rac_bucket = Bucket.from_bucket_name(
             self,
-            "Level1ARACBucket",
+            f"Level1ARACBucket{'Dev' if development else ''}",
             rac_bucket_name,
         )
 
         platform_bucket = Bucket.from_bucket_name(
             self,
-            "Level1APlatformBucket",
+            f"Level1APlatformBucket{'Dev' if development else ''}",
             platform_bucket_name,
         )
 
         mats_schedule_bucket = Bucket.from_bucket_name(
             self,
-            "Level1AMatsScheduleBucket",
+            f"Level1AMatsScheduleBucket{'Dev' if development else ''}",
             mats_schedule_bucket_name,
         )
 
         output_bucket = Bucket.from_bucket_name(
             self,
-            "Level1AOutputBucket",
+            f"Level1AOutputBucket{'Dev' if development else ''}",
             output_bucket_name,
         )
 
@@ -69,7 +70,7 @@ class Level1AStack(Stack):
 
         level1a_lambda = DockerImageFunction(
             self,
-            f"Level1ALambda{data_prefix}",
+            f"Level1ALambda{data_prefix}{'Dev' if development else ''}",
             code=DockerImageCode.from_image_asset("."),
             timeout=lambda_timeout,
             architecture=Architecture.X86_64,
@@ -80,14 +81,14 @@ class Level1AStack(Stack):
 
         event_queue = Queue(
             self,
-            f"Process{data_prefix}Queue",
+            f"Process{data_prefix}Queue{'Dev' if development else ''}",
             visibility_timeout=message_timeout,
             removal_policy=RemovalPolicy.RETAIN,
             dead_letter_queue=DeadLetterQueue(
                 max_receive_count=message_attempts,
                 queue=Queue(
                     self,
-                    f"Failed{data_prefix}ProcessQueue",
+                    f"Failed{data_prefix}ProcessQueue{'Dev' if development else ''}",  # noqa: E501
                     retention_period=queue_retention_period,
                 )
             )


### PR DESCRIPTION
Adapt the app and stack to allow deploying a parallel dev-pipeline. Add a github action which is mostly a copy of the one we already have, but with two changes:

- no automatic deploy on new releases
- sets env variable `MATS_DEVELOPMENT`

I think that, for the moment, this copy pasting is justified, but feel free to disagree.