### PR TITLE
Disambiguate overlaps and allow buffer

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -479,8 +479,8 @@ def lambda_handler(event: Event, context: Context):
         metadata.update({
             "L1ACode": code_version,
             "DataLevel": "L1A",
-            "DataBucket": output_bucket,
-            "DataPath": output_path,
+            "L1ADataBucket": output_bucket,
+            "L1ADataPath": output_path,
         })
         if "CODE" in metadata.keys():
             metadata["RACCode"] = metadata.pop("CODE")

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -61,6 +61,11 @@ PLATFORM_PARTITIONS = pa.schema([
     ("day", pa.int8()),
 ])
 
+SCHEDULE_PARTITIONS = pa.schema([
+    ("created_time", pa.int32()),
+])
+SCHEDULE_BUFFER = Timedelta(seconds=60)
+
 
 class DoesNotCover(Exception):
     pass
@@ -156,6 +161,7 @@ def get_mats_schedule_records(
     dataset = ds.dataset(
         path_or_bucket,
         filesystem=filesystem,
+        partitioning=ds.partitioning(SCHEDULE_PARTITIONS, flavor="filename"),
     ).to_table(
         filter=(
             (ds.field("start_date") <= max_time.asm8)
@@ -284,7 +290,7 @@ def get_search_bounds(
 
 
 def get_offset(frequency: float) -> Timedelta:
-    return OFFSET_FACTOR*Timedelta(seconds=1/frequency)
+    return OFFSET_FACTOR * Timedelta(seconds=1 / frequency)
 
 
 def interp_array(
@@ -341,28 +347,46 @@ def find_match(
     target_date: Timestamp,
     column: str,
     dataframe: DataFrame,
+    buffer: Optional[Timedelta] = None,
 ) -> Any:
     target_date.floor
     matches = dataframe[
         (dataframe["schedule_start_date"] <= target_date.asm8)
         & (dataframe["schedule_end_date"] >= target_date.floor('s').asm8)
     ].reset_index()
+
     if len(matches) > 1:
+        matches = matches[
+            matches["schedule_created_time"]
+            == matches["schedule_created_time"].max()
+        ].reset_index()
         if not (matches[column][0] == matches[column]).all():
             msg = f"Overlapping schedules for target date {target_date}"
             raise OverlappingSchedules(msg)
     elif len(matches) == 0:
+        if buffer is not None:
+            return find_match(
+                target_date - buffer,
+                column,
+                dataframe,
+                buffer=None,
+            )
         msg = f"Missing schedule for target date {target_date}"
         raise MissingSchedule(msg)
+
     return matches[column][0]
 
 
 def match_with_schedule(
     dataframe: DataFrame,
     target: DatetimeIndex,
+    buffer: Optional[Timedelta] = None,
 ) -> DataFrame:
     return DataFrame({
-        column: [find_match(ind, column, dataframe) for ind in target]
+        column: [
+            find_match(ind, column, dataframe, buffer)
+            for ind in target
+        ]
         for column in dataframe
     }, index=target)
 
@@ -508,6 +532,7 @@ def lambda_handler(event: Event, context: Context):
         matched_schedule = match_with_schedule(
             schedule_df,
             rac_df.index,
+            buffer=SCHEDULE_BUFFER,
         )
     except Exception as err:
         tb = '|'.join(format_tb(err.__traceback__)).replace('\n', ';')

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -91,7 +91,7 @@ class Level1AStack(Stack):
                 queue=Queue(
                     self,
                     "Failed" + queue_name,
-                    queuer_name="Failed" + queue_name,
+                    queue_name="Failed" + queue_name,
                     retention_period=queue_retention_period,
                 )
             )

--- a/stacks/level1a_stack.py
+++ b/stacks/level1a_stack.py
@@ -79,16 +79,19 @@ class Level1AStack(Stack):
             environment=environment,
         )
 
+        queue_name = f"Process{data_prefix}Queue{'Dev' if development else ''}"
         event_queue = Queue(
             self,
-            f"Process{data_prefix}Queue{'Dev' if development else ''}",
+            queue_name,
+            queue_name=queue_name,
             visibility_timeout=message_timeout,
             removal_policy=RemovalPolicy.RETAIN,
             dead_letter_queue=DeadLetterQueue(
                 max_receive_count=message_attempts,
                 queue=Queue(
                     self,
-                    f"Failed{data_prefix}ProcessQueue{'Dev' if development else ''}",  # noqa: E501
+                    "Failed" + queue_name,
+                    queuer_name="Failed" + queue_name,
                     retention_period=queue_retention_period,
                 )
             )

--- a/tests/level1a/handlers/conftest.py
+++ b/tests/level1a/handlers/conftest.py
@@ -64,6 +64,7 @@ def schedule() -> DataFrame:
                 Timestamp('2010-10-10 11:00:00.0'),
                 Timestamp('2010-10-10 12:00:00.0'),
             ],
+            "schedule_created_time": [0, 0, 0, 0, 0, 0, 0, 0],
             "Answer": [39, 40, 41, 42, 43, 44, -1, -2],
             "Fit": [1, 2, 3, 4, 5, 6, -1, -1],
         }

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -322,6 +322,17 @@ def test_find_match_raises_on_missing(schedule: pd.DataFrame):
         )
 
 
+def test_find_match_raises_on_missing_with_buffer(schedule: pd.DataFrame):
+    target_date = pd.DatetimeIndex(["1978-03-29T23:30:00"])[0]
+    with pytest.raises(MissingSchedule):
+        find_match(
+            target_date=target_date,
+            column="Answer",
+            dataframe=schedule,
+            buffer=pd.Timedelta(minutes=1),
+        )
+
+
 def test_find_match_raises_on_overlap(schedule: pd.DataFrame):
     target_date = pd.DatetimeIndex(["2010-10-10T10:10:10"])[0]
     with pytest.raises(OverlappingSchedules):
@@ -332,7 +343,7 @@ def test_find_match_raises_on_overlap(schedule: pd.DataFrame):
         )
 
 
-def test_find_match_does_not_raise_on_indentical_overlaps(
+def test_find_match_does_not_raise_on_identical_overlaps(
     schedule: pd.DataFrame,
 ):
     target_date = pd.DatetimeIndex(["2010-10-10T10:10:10"])[0]

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -138,9 +138,9 @@ def test_get_mats_schedule_records(schedule_path: Path):
         "schedule_end_date", "schedule_id", "schedule_name",
         "schedule_pointing_altitudes", "schedule_standard_altitude",
         "schedule_start_date", "schedule_version", "schedule_xml_file",
-        "schedule_yaw_correction",
+        "schedule_yaw_correction", "schedule_created_time",
     }
-    assert schedule_records.shape == (3, 11)
+    assert schedule_records.shape == (3, 12)
 
 
 @pytest.mark.parametrize("min_time,max_time,rows", (
@@ -301,8 +301,19 @@ def test_find_match(schedule: pd.DataFrame):
     assert answer == 42
 
 
+def test_find_match_with_buffer(schedule: pd.DataFrame):
+    target_date = pd.DatetimeIndex(["1978-03-29T23:30:00"])[0]
+    answer = find_match(
+        target_date=target_date,
+        column="Answer",
+        dataframe=schedule,
+        buffer=pd.Timedelta(hours=1),
+    )
+    assert answer == 42
+
+
 def test_find_match_raises_on_missing(schedule: pd.DataFrame):
-    target_date = pd.DatetimeIndex(["1978-12-24T22:30:00"])[0]
+    target_date = pd.DatetimeIndex(["1978-03-29T23:30:00"])[0]
     with pytest.raises(MissingSchedule):
         find_match(
             target_date=target_date,
@@ -331,6 +342,17 @@ def test_find_match_does_not_raise_on_indentical_overlaps(
         dataframe=schedule,
     )
     assert fit == -1
+
+
+def test_find_match_selects_latest_file(schedule: pd.DataFrame):
+    target_date = pd.DatetimeIndex(["2010-10-10T10:10:10"])[0]
+    schedule["schedule_created_time"] = [0, 0, 0, 0, 0, 0, 0, 1]
+    answer = find_match(
+        target_date=target_date,
+        column="Answer",
+        dataframe=schedule,
+    )
+    assert answer == -2
 
 
 def test_match_with_schedule(schedule: pd.DataFrame):
@@ -395,13 +417,14 @@ def test_lambda_handler(patched_s3):
         "HTR2OD", "HTR7A", "HTR7B", "HTR7OD", "HTR8A", "HTR8B", "HTR8OD",
         "satlat", "satlon", "satheight", "TPlat", "TPlon", "TPheight", "TPsza",
         "TPssa", "nadir_sza", "nadir_az", "TPlocaltime",
-        "schedule_description_long", "schedule_description_short",
-        "schedule_end_date", "schedule_id", "schedule_name",
-        "schedule_pointing_altitudes", "schedule_standard_altitude",
-        "schedule_start_date", "schedule_version", "schedule_xml_file",
-        "schedule_yaw_correction", "channel", "id", "flipped",
-        "temperature_ADC", "temperature", "temperature_HTR", "RAMSES", "AEZ",
-        "DataPath", "DataBucket", "RACCode", "L1ACode", "DataLevel", "INNOSAT",
+        "schedule_created_time", "schedule_description_long",
+        "schedule_description_short", "schedule_end_date", "schedule_id",
+        "schedule_name", "schedule_pointing_altitudes",
+        "schedule_standard_altitude", "schedule_start_date", "schedule_version",
+        "schedule_xml_file", "schedule_yaw_correction", "channel", "id",
+        "flipped", "temperature_ADC", "temperature", "temperature_HTR",
+        "RAMSES", "AEZ", "DataPath", "DataBucket", "RACCode", "L1ACode",
+        "DataLevel", "INNOSAT",
     }
     assert len(df) == 4
 
@@ -448,7 +471,7 @@ def test_lambda_handler_no_htr(patched_s3):
         "TPlocaltime", "TPlon", "TPssa", "TPsza", "VCFrameCounter", "Warnings",
         "afsAttitudeState", "afsGnssStateJ2000", "afsTPLongLatGeod",
         "afsTangentH_wgs84", "afsTangentPointECI", "index", "nadir_sza",
-        "nadir_az", "satheight", "satlat", "satlon",
+        "nadir_az", "satheight", "satlat", "satlon", "schedule_created_time",
         "schedule_description_long", "schedule_description_short",
         "schedule_end_date", "schedule_id", "schedule_name",
         "schedule_pointing_altitudes", "schedule_standard_altitude",

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -423,7 +423,7 @@ def test_lambda_handler(patched_s3):
         "schedule_standard_altitude", "schedule_start_date", "schedule_version",
         "schedule_xml_file", "schedule_yaw_correction", "channel", "id",
         "flipped", "temperature_ADC", "temperature", "temperature_HTR",
-        "RAMSES", "AEZ", "DataPath", "DataBucket", "RACCode", "L1ACode",
+        "RAMSES", "AEZ", "L1ADataPath", "L1ADataBucket", "RACCode", "L1ACode",
         "DataLevel", "INNOSAT",
     }
     assert len(df) == 4
@@ -476,7 +476,7 @@ def test_lambda_handler_no_htr(patched_s3):
         "schedule_end_date", "schedule_id", "schedule_name",
         "schedule_pointing_altitudes", "schedule_standard_altitude",
         "schedule_start_date", "schedule_version", "schedule_xml_file",
-        "schedule_yaw_correction", "DataPath", "DataBucket", "L1ACode",
+        "schedule_yaw_correction", "L1ADataPath", "L1ADataBucket", "L1ACode",
         "DataLevel",
     }
     assert len(df) == 8


### PR DESCRIPTION
This disambiguates schedule timeline overlaps according to the following:
- if overlaps have different file timestamps, pick latest,
- if there are still overlaps, raise `OverlappingSchedules` as before,
- otherwise return match.

This also allows a short buffer of 60 seconds after schedule, in case instructions are slow to trigger compared to schedule:
- first call is made with a buffer of 60 seconds,
- if no match is found without the buffer, a second call is made with no buffer, but target time adjusted by the buffer length, _(I know this sounds a bit weird, but it was the easiest and most robust implementation I could think of)_
- if there is still no match, raise `MissingSchedule` as before,
- otherwise return match.

This also adds a new column `schedule_created_time` which might be helpful for tracking where a particular schedule data-row was taken from.