### PR TITLE
Alter dummy schedule

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -76,10 +76,10 @@ DUMMY_SCHEDULE: Dict[str, Any] = {
     "schedule_version": 0,
     "schedule_standard_altitude": 0,
     "schedule_yaw_correction": False,
-    "schedule_pointing_altitudes": [],
+    "schedule_pointing_altitudes": "[]",
     "schedule_xml_file": "",
     "schedule_description_short": "",
-    "schedule_description_long": "",
+    "schedule_description_long": "[]",
     "Answer": -42,
 }
 


### PR DESCRIPTION
This changes the types in the dummy schedule to match the types in the parquet. It would perhaps be better if they were actually lists, but that would require a migration of the schedule-timeline generator and a re-run of L1A and L1B, so maybe not worth it. For this version, I think this fix is what we should go with.

@OleMartinChristensen: if you think this should be implemented later, let me know, and I will create issues for it.

Resolves #63 

