### PR TITLE
Disambiguate schedule based on xmls

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -76,10 +76,10 @@ DUMMY_SCHEDULE: Dict[str, Any] = {
     "schedule_version": 0,
     "schedule_standard_altitude": 0,
     "schedule_yaw_correction": False,
-    "schedule_pointing_altitudes": "[]",
+    "schedule_pointing_altitudes": [],
     "schedule_xml_file": "",
     "schedule_description_short": "",
-    "schedule_description_long": "[]",
+    "schedule_description_long": "",
     "Answer": -42,
 }
 

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -76,10 +76,10 @@ DUMMY_SCHEDULE: Dict[str, Any] = {
     "schedule_version": 0,
     "schedule_standard_altitude": 0,
     "schedule_yaw_correction": False,
-    "schedule_pointing_altitudes": [],
+    "schedule_pointing_altitudes": "[]",
     "schedule_xml_file": "",
     "schedule_description_short": "",
-    "schedule_description_long": "",
+    "schedule_description_long": "[]",
     "Answer": -42,
 }
 

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -365,6 +365,15 @@ def interpolate(
 
 
 def disambiguate_matches(matches: DataFrame) -> Any:
+    for column in matches.columns:
+        if column in ("schedule_version", "schedule_xml_file"):
+            continue
+        if not (matches[column].apply(
+            lambda x: x == matches[column][0])
+        ).all():
+            msg = f"column {column} differs for interval"
+            raise OverlappingSchedulesError(msg)
+
     generation_dates: Set[str] = set()
     execution_dates: Set[str] = set()
     versions: Set[str] = set()
@@ -389,12 +398,6 @@ def disambiguate_matches(matches: DataFrame) -> Any:
 
     matches = matches[matches["schedule_xml_file"].str.contains(desired)]
     if len(matches) != 1:
-        for column in matches.columns:
-            if not (matches[column].apply(
-                lambda x: x == matches[column][0])
-            ).all():
-                msg = f"column {column} differs for interval"
-                raise OverlappingSchedulesError(msg)
         msg = "unknown problem for interval"
         raise OverlappingSchedulesError(msg)
 

--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -5,7 +5,7 @@ from functools import wraps
 from http import HTTPStatus
 from time import sleep
 from traceback import format_tb
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Set, Tuple
 
 import numpy as np
 import pyarrow as pa  # type: ignore
@@ -100,7 +100,11 @@ class RetriesExceeded(Exception):
     pass
 
 
-class OverlappingSchedules(Exception):
+class OverlappingSchedulesError(Exception):
+    pass
+
+
+class OverlappingSchedulesWarning(Warning):
     pass
 
 
@@ -360,6 +364,44 @@ def interpolate(
     }, index=target)
 
 
+def disambiguate_matches(matches: DataFrame) -> Any:
+    for column in matches.columns:
+        if column == "schedule_xml_file":
+            continue
+        if not (matches[column][0] == matches[column]).all():
+            msg = f"column {column} differs for interval"
+            raise OverlappingSchedulesError(msg)
+
+    generation_dates: Set[str] = set()
+    execution_dates: Set[str] = set()
+    versions: Set[str] = set()
+    for data in matches["schedule_xml_file"]:
+        temp = data.split("_")[1]
+        generation_dates = generation_dates.union({temp[0: 6]})
+        execution_dates = execution_dates.union({temp[6: 12]})
+        versions = versions.union({temp[12: 14]})
+
+    if len(execution_dates) != 1:
+        msg = "execution dates differ for interval"
+        raise OverlappingSchedulesError(msg)
+    execution_date = list(execution_dates)[0]
+
+    if len(generation_dates) != 1:
+        desired = "_" + execution_date + sorted(generation_dates)[-1]
+    elif len(versions) != 1:
+        generation_date = list(generation_dates)[0]
+        desired = "_" + execution_date + generation_date + sorted(versions)[-1]
+    else:
+        desired = ""
+
+    matches = matches[matches["schedule_xml_file"].str.contains(desired)]
+    if len(matches > 1):
+        msg = "unknown problem for interval"
+        raise OverlappingSchedulesError(msg)
+
+    return matches.reset_index()
+
+
 def find_match(
     target_date: Timestamp,
     column: str,
@@ -379,7 +421,11 @@ def find_match(
         ].reset_index()
         if not (matches[column][0] == matches[column]).all():
             msg = f"Overlapping schedules for target date {target_date}"
-            raise OverlappingSchedules(msg)
+            try:
+                matches = disambiguate_matches(matches)
+                warnings.warn(msg, OverlappingSchedulesWarning)
+            except OverlappingSchedulesError as err:
+                raise OverlappingSchedulesError(f"{msg}: {err}")
     elif len(matches) == 0:
         if buffer is not None:
             return find_match(

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any, Dict
 from unittest.mock import patch
 
 import numpy as np
@@ -11,6 +12,7 @@ import pytest  # type: ignore
 from level1a.handlers.level1a import (
     HTR_COLUMNS,
     covers,
+    disambiguate_matches,
     find_match,
     get_level0_records,
     get_htr_records,
@@ -24,7 +26,7 @@ from level1a.handlers.level1a import (
     match_with_schedule,
     parse_event_message,
     MissingSchedule,
-    OverlappingSchedules,
+    OverlappingSchedulesError,
 )
 
 
@@ -291,6 +293,98 @@ def test_interpolate_with_max_diff_returns_nan():
     )
 
 
+@pytest.mark.parametrize("csv_data, expected", [
+    [
+        {
+            "schedule_start_date": [
+                "2022-12-19 18:00:00",
+                "2022-12-19 18:00:00",
+            ],
+            "schedule_end_date": [
+                "2022-12-19 23:59:59",
+                "2022-12-19 23:59:59",
+            ],
+            "schedule_id": [3105, 3106],
+            "schedule_name": ["MODE1y", "MODE1y"],
+            "schedule_version": [2, 1],
+            "schedule_standard_altitude": [92500, 92500],
+            "schedule_yaw_correction": [True, True],
+            "schedule_pointing_altitudes": [[], []],
+            "schedule_xml_file": [
+                "STP-MTS-3105_22121922121902TMODE1y.xml",
+                "STP-MTS-3106_22121922121901TMODE1y.xml",
+            ],
+            "schedule_description_short": [
+                "Operational mode",
+                "Operational mode",
+            ],
+            "schedule_description_long": [
+                "Mode 1. JPEGQ = 90  (should have been 80)",
+                "Mode 1. JPEGQ = 90",
+            ],
+        },
+        "STP-MTS-3105_22121922121902TMODE1y.xml",
+    ],
+    [
+        {
+            "schedule_start_date": ["2023-04-13", "2023-04-13"],
+            "schedule_end_date": [
+                "2023-04-13 23:59:56",
+                "2023-04-13 23:59:56",
+            ],
+            "schedule_id": [1207, 1207],
+            "schedule_name": ["CROPD", "CROPD"],
+            "schedule_version": [3, 3],
+            "schedule_standard_altitude": [87500, 87500],
+            "schedule_yaw_correction": [True, True],
+            "schedule_pointing_altitudes": [[], []],
+            "schedule_xml_file": [
+                "STP-MTS-1207_23041323041103TCROPD.xml",
+                "STP-MTS-1207_23041323041003TCROPD.xml",
+            ],
+            "schedule_description_short": ["", ""],
+            "schedule_description_long": ["", ""],
+        },
+        "STP-MTS-1207_23041323041103TCROPD.xml",
+    ]
+])
+def test_disambiguate_matches(csv_data: dict, expected: str):
+    dataframe = pd.DataFrame.from_dict(csv_data)
+    matches = disambiguate_matches(dataframe)
+    pd.testing.assert_frame_equal(
+        matches,
+        dataframe[dataframe["schedule_xml_file"] == expected].reset_index(),
+    )
+
+
+@pytest.mark.parametrize("csv_data, expected", [
+    [
+        {
+            "Answer": [42, 43],
+            "schedule_xml_file": [
+                "STP-MTS-1207_23041323041103TCROPD.xml",
+                "STP-MTS-1207_23041323041103TCROPD.xml",
+            ],
+        },
+        "column Answer differs"
+    ],
+    [
+        {
+            "Answer": [42, 42],
+            "schedule_xml_file": [
+                "STP-MTS-1207_23041323041103TCROPD.xml",
+                "STP-MTS-1207_23041223041103TCROPD.xml",
+            ],
+        },
+        "execution dates differ",
+    ],
+])
+def test_disambiguate_matches_raises(csv_data: Dict[str, Any], expected: str):
+    dataframe = pd.DataFrame.from_dict(csv_data)
+    with pytest.raises(OverlappingSchedulesError, match=expected):
+        _ = disambiguate_matches(dataframe)
+
+
 def test_find_match(schedule: pd.DataFrame):
     target_date = pd.DatetimeIndex(["1978-03-29T22:42:00"])[0]
     answer = find_match(
@@ -330,16 +424,6 @@ def test_find_match_warns_on_missing_with_buffer(schedule: pd.DataFrame):
             column="Answer",
             dataframe=schedule,
             buffer=pd.Timedelta(minutes=1),
-        )
-
-
-def test_find_match_raises_on_overlap(schedule: pd.DataFrame):
-    target_date = pd.DatetimeIndex(["2010-10-10T10:10:10"])[0]
-    with pytest.raises(OverlappingSchedules):
-        find_match(
-            target_date=target_date,
-            column="Answer",
-            dataframe=schedule,
         )
 
 

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -294,7 +294,7 @@ def test_interpolate_with_max_diff_returns_nan():
 
 
 @pytest.mark.parametrize("csv_data, expected", [
-    [
+    [  # Select higher version
         {
             "schedule_start_date": [
                 "2022-12-19 18:00:00",
@@ -304,7 +304,7 @@ def test_interpolate_with_max_diff_returns_nan():
                 "2022-12-19 23:59:59",
                 "2022-12-19 23:59:59",
             ],
-            "schedule_id": [3105, 3106],
+            "schedule_id": [3105, 3105],
             "schedule_name": ["MODE1y", "MODE1y"],
             "schedule_version": [2, 1],
             "schedule_standard_altitude": [92500, 92500],
@@ -320,12 +320,12 @@ def test_interpolate_with_max_diff_returns_nan():
             ],
             "schedule_description_long": [
                 "Mode 1. JPEGQ = 90  (should have been 80)",
-                "Mode 1. JPEGQ = 90",
+                "Mode 1. JPEGQ = 90  (should have been 80)",
             ],
         },
         "STP-MTS-3105_22121922121902TMODE1y.xml",
     ],
-    [
+    [  # Select latest generation date
         {
             "schedule_start_date": ["2023-04-13", "2023-04-13"],
             "schedule_end_date": [


### PR DESCRIPTION
This disambiguates schedules based on the XML-name:

1. if columns (except version and xml file) differ, raise error
2. extract execution dates, generation dates and versions from names
3. if execution dates differ, raise error
4. if generation dates differ, use latest
5. if versions differ, use latest
6. if there are still duplicates, raise error (should not happen)
7. always warn that overlaps occurred, even if we manage to disambiguate

Resolves #62 