### PR TITLE
Make pointing list in dummy again

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -76,10 +76,10 @@ DUMMY_SCHEDULE: Dict[str, Any] = {
     "schedule_version": 0,
     "schedule_standard_altitude": 0,
     "schedule_yaw_correction": False,
-    "schedule_pointing_altitudes": "[]",
+    "schedule_pointing_altitudes": [],
     "schedule_xml_file": "",
     "schedule_description_short": "",
-    "schedule_description_long": "[]",
+    "schedule_description_long": "",
     "Answer": -42,
 }
 


### PR DESCRIPTION
Make pointing list in dummy schedule again. To be merged and deployed after https://github.com/innosat-mats/mats-timeline-schedule/pull/4.

Note: Will require reprocessing of Level1A.