### PR TITLE
Correct nadir az sun direction

### DIFF
--- a/level1a/handlers/level1a.py
+++ b/level1a/handlers/level1a.py
@@ -434,7 +434,7 @@ def add_satellite_position_data(
         result_type="expand",
     )
 
-    dataframe[["nadir_sza", "TPsza", "TPssa", "nadir_az"]] = dataframe.apply(
+    dataframe[["TPsza", "TPssa", "nadir_sza", "nadir_az"]] = dataframe.apply(
         lambda s: solar_angles(
             timescale.from_datetime(s[index].to_pydatetime()),
             s.satlat, s.satlon, s.satheight,

--- a/level1a/handlers/mats_utils/coordinates.py
+++ b/level1a/handlers/mats_utils/coordinates.py
@@ -58,18 +58,15 @@ def solar_angles(
         tp_alt (float):     altitude (metres)
 
     Returns:
-        float:  solar zenith angle at satellite position (degrees)
         float:  solar zenith angle at TP position (degrees)
         float:  solar scattering angle at TP position (degrees)
+        float:  solar zenith angle at satellite position (degrees)
         float:  solar azimuth angle at nadir imager (degrees)
     """
     earth, sun = PLANETS['earth'], PLANETS['sun']
 
     try:
         sat_pos = earth + wgs84.latlon(sat_lat, sat_lon, elevation_m=sat_alt)
-        sun_dir = sat_pos.at(time).observe(sun).apparent()
-        obs_sun = sun_dir.altaz()
-        nadir_sza = (90 - obs_sun[0].degrees)
 
         tp_pos = earth + wgs84.latlon(tp_lat, tp_lon, elevation_m=tp_alt)
         fov = (tp_pos - sat_pos).at(time).position.m
@@ -81,11 +78,14 @@ def solar_angles(
             np.dot(fov, sun_dir.position.m / norm(sun_dir.position.m))
         ))
 
+        sun_dir = sat_pos.at(time).observe(sun).apparent()
+        obs_sun = sun_dir.altaz()
         limb_dir = tp_pos.at(time) - sat_pos.at(time)
         obs_limb = limb_dir.altaz()
+        nadir_sza = (90 - obs_sun[0].degrees)
         nadir_az = (obs_sun[1].degrees - obs_limb[1].degrees)
 
-        return nadir_sza, tp_sza, tp_ssa, nadir_az
+        return tp_sza, tp_ssa, nadir_sza, nadir_az
     except EphemerisRangeError:
         return np.nan, np.nan, np.nan, np.nan
 

--- a/tests/level1a/handlers/test_level1a.py
+++ b/tests/level1a/handlers/test_level1a.py
@@ -389,6 +389,7 @@ def test_match_with_schedule(schedule: pd.DataFrame):
     "DATA_PREFIX": "CCD",
     "TIME_COLUMN": "EXPDate",
 })
+@pytest.mark.filterwarnings("ignore:Discarding nonzero nanoseconds")
 def test_lambda_handler(patched_s3):
     out_dir = os.environ["OUTPUT_BUCKET"]
     (Path(out_dir) / "2022" / "12" / "21" / "23").mkdir(parents=True)


### PR DESCRIPTION
Use satellite position for sun direction when calculating `nadir_az`. (I changed the "physical" order of the columns in doing so, but that should not have any consequence for the user, unless they do some weird kind of processing.)

In addition I silenced som unrelated warnings to do with unit conversion of time stamps.

Resolves #68 