### PR TITLE
Update tempertature definitions

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,8 +23,8 @@ if development:
     output_bucket_ccd = "dev-payload-level1a"
     output_bucket_pm = "dev-payload-level1a-pm"
 else:
-    output_bucket_ccd = "ops-payload-level1a-v0.7"
-    output_bucket_pm = "ops-payload-level1a-pm-v0.3"
+    output_bucket_ccd = "ops-payload-level1a-v0.8"
+    output_bucket_pm = "ops-payload-level1a-pm-v0.4"
 rac_bucket_name = "ops-payload-level0-v0.3"
 platform_bucket_name = "ops-platform-level1a-v0.3"
 mats_schedule_bucket_name = "ops-mats-schedule-v0.2"

--- a/level1a/handlers/mats_utils/ccd_item.py
+++ b/level1a/handlers/mats_utils/ccd_item.py
@@ -13,6 +13,11 @@ channel_num_to_str: Dict[int, str] = {
     7: "NADIR",
 }
 
+channel_to_tempertature: Dict[str, str] = {
+    "UV1": "HTR8B",
+    "UV2": "HTR8A",
+}
+
 
 def add_ccd_item_attributes(ccd_data: DataFrame) -> None:
     """Add some attributes to CCD data that we need.
@@ -48,5 +53,13 @@ def add_ccd_item_attributes(ccd_data: DataFrame) -> None:
     # This needs to be updated when a better temperature estimate has been
     # designed. For now a de facto implementation of
     # get_temperature.add_temperature_info()
-    ccd_data["temperature"] = ccd_data["HTR8A"]
+
+    temperatures = [
+        ccd_item[channel_to_tempertature[ccd_item["channel"]]]
+        if ccd_item["channel"].startswith("UV")
+        else (ccd_item["HTR8A"] + ccd_item["HTR8B"]) * 0.5
+        for _, ccd_item in ccd_data.iterrows()
+    ]
+
+    ccd_data["temperature"] = temperatures
     ccd_data["temperature_HTR"] = 0.5 * (ccd_data["HTR8A"] + ccd_data["HTR8B"])


### PR DESCRIPTION
Update temperature definitions so that `UV1` uses `HTR8B`, `UV2` uses `HTR8A` and all others use the average of `HTR8A` and `HTR8B`.

Also bump versions. I'll mark this as draft until you have decided what versions you want, but feel free to review anyway.